### PR TITLE
feat: add `/api/metadata/instances` endpoint and structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+reqwest = "0.11.18"
 serde = { version = "1.0.173", features = ["derive"] }
 serde_json = "1.0"

--- a/src/endpoints/instances.rs
+++ b/src/endpoints/instances.rs
@@ -1,0 +1,291 @@
+use reqwest;
+use serde_json;
+
+use crate::structs::instances_response::InstancesResponse;
+
+#[derive(Debug)]
+
+pub enum Error {
+    ReqwestError(reqwest::Error),
+    SerdeError(serde_json::Error),
+}
+
+/// Query the `/api/metadata/instances` endpoint and produce an `InstancesResponse` or an
+/// `InstancesError`.
+///
+/// # Tensordock API Docs:
+///
+/// Here is where you can retrieve data about the restrictions placed on instances.
+/// 
+/// ## CPU Instances:
+///
+/// You can retrieve the cost, the locations where a specific type of CPU can be deployed, and the
+/// specifications.
+/// 
+/// CPU instances come in multiples of 1 vCPU and 4 GB of RAM. We guarantee that you can utilize
+/// your CPU 24x7 without any throttling. Each multiple costs the costHr, and you can combine
+/// multiples up to the maxMultiples number shown.
+/// 
+/// ## GPU Instances:
+/// 
+/// You can get the cost, the name, some performance metrics, the restrictions, as well as the
+/// locations that they are available in.
+/// 
+/// ## Notes
+/// 
+/// Units can be interpreted through common sense, unless otherwise noted. E.g. 4 for a RAM field
+/// translates to 4GB of RAM, and 10 for the network port translates to a 10 Gbps (1.25 GB/s) port.
+///
+/// # Errors
+/// Will return `Err` if
+/// - `reqwest` produces an `Err` from querying the endpoint
+/// - `serde_json` fails to parse the response's body
+pub async fn get() -> Result<InstancesResponse, Error> {
+    match get_raw_instances_body().await {
+        Ok(s) => parse_raw_instances_body(&s),
+        Err(e) => Err(Error::ReqwestError(e)),
+    }
+}
+
+async fn get_raw_instances_body() -> Result<String, reqwest::Error> {
+    let raw_body = reqwest::get("https://console.tensordock.com/api/metadata/instances")
+        .await?
+        .text()
+        .await?;
+
+    Ok(raw_body)
+}
+
+fn parse_raw_instances_body(body: &str) -> Result<InstancesResponse, Error> {
+    let instances_result: Result<InstancesResponse, serde_json::Error> =
+        serde_json::from_str(body);
+    match instances_result {
+        Ok(instances) => Ok(instances),
+        Err(e) => Err(Error::SerdeError(e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::structs::{
+        global_resources::GlobalResources,
+        gpu_instances::{GpuInstances, GpuInstancesDescription},
+        instance::{CpuInstance, GpuInstance},
+        instances_response::InstancesResponse,
+        location::Location,
+        resources::Resources,
+        specs::{CpuSpecs, GpuSpecs},
+        storage_option::StorageOption,
+    };
+
+    use super::parse_raw_instances_body;
+
+    #[test]
+    fn test_basic_parse() {
+        // Arrange
+        let body = "
+{
+  \"cpu\": {
+    \"AMD_EPYC_MILAN\": {
+      \"cost\": {
+        \"costCommit1Yr\": 282.51,
+        \"costCommit2Yr\": 452.02,
+        \"costHr\": 0.043
+      },
+      \"locations\": [
+        \"na-us-las-1\",
+        \"na-us-nyc-1\",
+        \"na-us-chi-1\"
+      ],
+      \"name\": \"AMD EPYC Milan\",
+      \"restrictions\": {
+        \"maxMultiples\": 44,
+        \"maxRAMPerInstance\": 176
+      },
+      \"specs\": {
+        \"avx1\": true,
+        \"avx2\": true,
+        \"avx512\": false,
+        \"gbps\": 10,
+        \"ram\": 4
+      }
+    }
+  },
+  \"gpu\": {
+    \"A100_40GB\": {
+      \"cost\": {
+        \"costCommit1Yr\": 14913.9,
+        \"costCommit2Yr\": 23862.24,
+        \"costHr\": 2.27
+      },
+      \"locations\": [
+        \"na-us-chi-1\"
+      ],
+      \"name\": \"NVIDIA A100 40GB for PCIE\",
+      \"restrictions\": {
+        \"maxGPUsPerInstance\": 8,
+        \"maxRAMPerInstance\": 492,
+        \"maxRAMPervCPU\": 24,
+        \"maxvCPUsPerGPU\": 18,
+        \"maxvCPUsPerInstance\": 94,
+        \"minRamPervCPU\": 1,
+        \"minvCPUsPerGPU\": 1
+      },
+      \"specs\": {
+        \"cudaCores\": 6912,
+        \"gbps\": 10,
+        \"nvlink\": false,
+        \"singlePrecisionPerformance\": 19.5,
+        \"vram\": 40
+      }
+    }
+  },
+  \"resources\": {
+    \"global\": {
+      \"locations\": {
+        \"na-us-bos-1\": {
+          \"connectivity\": {},
+          \"deployable\": false,
+          \"name\": \"Boston DC 1\",
+          \"reservable\": true,
+          \"timezone\": \"UTC-5\"
+        }
+      },
+      \"storage\": {
+        \"io1\": {
+          \"costHr\": 0.0001,
+          \"description\": \"Perfomance-optimized NVMe SSD\",
+          \"locations\": [
+            \"na-us-bos-1\",
+            \"na-us-bos-2\",
+            \"na-us-chi-1\",
+            \"na-us-las-1\",
+            \"na-us-nyc-1\",
+            \"oc-sg-sin-1\"
+          ],
+          \"unit\": \"per allocated GB of storage\"
+        }
+      }
+    },
+    \"gpu_instances\": {
+      \"ram\": {
+        \"costHr\": 0.005,
+        \"unit\": \"per allocated GB of RAM\"
+      },
+      \"vcpu\": {
+        \"costHr\": 0.01,
+        \"unit\": \"per allocated vCPU\"
+      }
+    }
+  },
+  \"success\": true
+}
+";
+        let expected = InstancesResponse {
+            cpu: BTreeMap::from([(
+                String::from("AMD_EPYC_MILAN"),
+                CpuInstance {
+                    name: String::from("AMD EPYC Milan"),
+                    cost: BTreeMap::from([
+                        (String::from("costCommit1Yr"), 282.51),
+                        (String::from("costCommit2Yr"), 452.02),
+                        (String::from("costHr"), 0.043),
+                    ]),
+                    locations: vec![
+                        String::from("na-us-las-1"),
+                        String::from("na-us-nyc-1"),
+                        String::from("na-us-chi-1"),
+                    ],
+                    restrictions: BTreeMap::from([
+                        (String::from("maxMultiples"), 44),
+                        (String::from("maxRAMPerInstance"), 176),
+                    ]),
+                    specs: CpuSpecs {
+                        avx1: true,
+                        avx2: true,
+                        avx512: false,
+                        gbps: 10,
+                        ram: 4,
+                    },
+                },
+            )]),
+            gpu: BTreeMap::from([(
+                String::from("A100_40GB"),
+                GpuInstance {
+                    name: String::from("NVIDIA A100 40GB for PCIE"),
+                    cost: BTreeMap::from([
+                        (String::from("costCommit1Yr"), 14913.9),
+                        (String::from("costCommit2Yr"), 23862.24),
+                        (String::from("costHr"), 2.27),
+                    ]),
+                    locations: vec![String::from("na-us-chi-1")],
+                    restrictions: BTreeMap::from([
+                        (String::from("maxGPUsPerInstance"), 8),
+                        (String::from("maxRAMPerInstance"), 492),
+                        (String::from("maxRAMPervCPU"), 24),
+                        (String::from("maxvCPUsPerGPU"), 18),
+                        (String::from("maxvCPUsPerInstance"), 94),
+                        (String::from("minRamPervCPU"), 1),
+                        (String::from("minvCPUsPerGPU"), 1),
+                    ]),
+                    specs: GpuSpecs {
+                        cuda_cores: 6912,
+                        gbps: 10,
+                        nvlink: false,
+                        single_precision_performance: 19.5,
+                        vram: 40,
+                    },
+                },
+            )]),
+            resources: Resources {
+                global: GlobalResources {
+                    locations: BTreeMap::from([(
+                        String::from("na-us-bos-1"),
+                        Location {
+                            name: String::from("Boston DC 1"),
+                            connectivity: BTreeMap::from([]),
+                            deployable: false,
+                            reservable: true,
+                            timezone: String::from("UTC-5"),
+                        },
+                    )]),
+                    storage: BTreeMap::from([(
+                        String::from("io1"),
+                        StorageOption {
+                            cost_hr: 0.0001,
+                            description: String::from("Perfomance-optimized NVMe SSD"),
+                            locations: vec![
+                                String::from("na-us-bos-1"),
+                                String::from("na-us-bos-2"),
+                                String::from("na-us-chi-1"),
+                                String::from("na-us-las-1"),
+                                String::from("na-us-nyc-1"),
+                                String::from("oc-sg-sin-1"),
+                            ],
+                            unit: String::from("per allocated GB of storage"),
+                        },
+                    )]),
+                },
+                gpu_instances: GpuInstances {
+                    ram: GpuInstancesDescription {
+                        cost_hr: 0.005,
+                        unit: String::from("per allocated GB of RAM"),
+                    },
+                    vcpu: GpuInstancesDescription {
+                        cost_hr: 0.01,
+                        unit: String::from("per allocated vCPU"),
+                    },
+                },
+            },
+            success: true,
+        };
+
+        // Act
+        let result = parse_raw_instances_body(body);
+
+        // Assert
+        assert_eq!(result.unwrap(), expected);
+    }
+}

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -1,0 +1,1 @@
+pub mod instances;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_name_repetitions)]
+
 pub mod endpoints;
 pub mod structs;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-mod structs;
+pub mod endpoints;
+pub mod structs;
 
 pub fn add(left: usize, right: usize) -> usize {
     left + right

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod structs;
+
 pub fn add(left: usize, right: usize) -> usize {
     left + right
 }

--- a/src/structs/global_resources.rs
+++ b/src/structs/global_resources.rs
@@ -1,0 +1,13 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use super::location::Location;
+use super::storage_option::StorageOption;
+
+/// `GlobalResources` represents a collection of available locations and storages.
+#[derive(Deserialize, Debug, PartialEq)]
+pub struct GlobalResources {
+    pub locations: BTreeMap<String, Location>,
+    pub storage: BTreeMap<String, StorageOption>,
+}

--- a/src/structs/gpu_instances.rs
+++ b/src/structs/gpu_instances.rs
@@ -1,0 +1,20 @@
+use serde::Deserialize;
+
+/// A container for the units of expected cost for RAM and vCPUs for GPU
+/// instances.
+#[derive(Deserialize, PartialEq, Debug)]
+pub struct GpuInstances {
+    pub ram: GpuInstancesDescription,
+    pub vcpu: GpuInstancesDescription,
+}
+
+/// A description of the costs for GPU instances.
+#[derive(Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GpuInstancesDescription {
+    /// The expected hourly cost of a GPU instance.
+    pub cost_hr: f64,
+    /// The unit of measurement against which the expected hourly cost is
+    /// multiplied.
+    pub unit: String,
+}

--- a/src/structs/instance.rs
+++ b/src/structs/instance.rs
@@ -1,0 +1,29 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use super::specs::{CpuSpecs, GpuSpecs};
+
+/// A `CpuInstance` represents an available CPU instance, containing
+/// information about costs for certain lengths, available locations,
+/// restrictions on usage, and specs of the instance.
+#[derive(Deserialize, PartialEq, Debug)]
+pub struct CpuInstance {
+    pub name: String,
+    pub cost: BTreeMap<String, f64>,
+    pub locations: Vec<String>,
+    pub restrictions: BTreeMap<String, u32>,
+    pub specs: CpuSpecs,
+}
+
+/// A `GpuInstance` represents an available GPU instance, containing
+/// information about costs for certain lengths, available locations,
+/// restrictions on usage, and specs of the instance.
+#[derive(Deserialize, PartialEq, Debug)]
+pub struct GpuInstance {
+    pub name: String,
+    pub cost: BTreeMap<String, f64>,
+    pub locations: Vec<String>,
+    pub restrictions: BTreeMap<String, u32>,
+    pub specs: GpuSpecs,
+}

--- a/src/structs/instances_response.rs
+++ b/src/structs/instances_response.rs
@@ -1,0 +1,19 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use super::{
+    instance::{CpuInstance, GpuInstance},
+    resources::Resources,
+};
+
+/// An `InstancesResponse` represents a response of the `/api/metadata/instances`
+/// endpoint, containing information about available CPUs, GPUs, and other
+/// resources.
+#[derive(Deserialize, PartialEq, Debug)]
+pub struct InstancesResponse {
+    pub cpu: BTreeMap<String, CpuInstance>,
+    pub gpu: BTreeMap<String, GpuInstance>,
+    pub resources: Resources,
+    pub success: bool,
+}

--- a/src/structs/location.rs
+++ b/src/structs/location.rs
@@ -1,0 +1,18 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+/// A Location represents an available resource location.
+#[derive(Deserialize, Debug, PartialEq, Eq)]
+pub struct Location {
+    pub name: String,
+    /// Containing the endpoints to test connectivity with for performance, or
+    /// an IP to test against.
+    pub connectivity: BTreeMap<String, String>,
+    /// Whether the location can be deployed as a server.
+    pub deployable: bool,
+    /// Whether the location is reservable as a server.
+    pub reservable: bool,
+    /// The timezone as a string, in a format like "UTC-6".
+    pub timezone: String,
+}

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -1,0 +1,8 @@
+pub mod global_resources;
+pub mod gpu_instances;
+pub mod instance;
+pub mod instances_response;
+pub mod location;
+pub mod resources;
+pub mod specs;
+pub mod storage_option;

--- a/src/structs/resources.rs
+++ b/src/structs/resources.rs
@@ -1,0 +1,10 @@
+use serde::Deserialize;
+
+use super::{global_resources::GlobalResources, gpu_instances::GpuInstances};
+
+/// Resources represents the available resources to access.
+#[derive(Deserialize, PartialEq, Debug)]
+pub struct Resources {
+    pub global: GlobalResources,
+    pub gpu_instances: GpuInstances,
+}

--- a/src/structs/specs.rs
+++ b/src/structs/specs.rs
@@ -1,0 +1,23 @@
+use serde::Deserialize;
+
+/// A `CpuSpecs` represents the specifications of a CPU instance.
+#[derive(Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CpuSpecs {
+    pub avx1: bool,
+    pub avx2: bool,
+    pub avx512: bool,
+    pub gbps: u32,
+    pub ram: u32,
+}
+
+/// A `GpuSpecs` represents the specifications of a GPU instance.
+#[derive(Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GpuSpecs {
+    pub cuda_cores: u32,
+    pub gbps: u32,
+    pub nvlink: bool,
+    pub single_precision_performance: f64,
+    pub vram: u32,
+}

--- a/src/structs/storage_option.rs
+++ b/src/structs/storage_option.rs
@@ -1,0 +1,14 @@
+use serde::Deserialize;
+
+/// A `StorageOption` represents an option for storage, like an SSD or HDD.
+#[derive(Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageOption {
+    /// The hourly expected cost of using the given storage option.
+    pub cost_hr: f64,
+    /// A description of the type of storage option.
+    pub description: String,
+    /// A collection of locations available for the given storage option.
+    pub locations: Vec<String>,
+    pub unit: String,
+}


### PR DESCRIPTION
This PR introduces several structs that represent a response when querying the `/api/metadata/instances` endpoint, along with a function `crate::endpoints::instances::get` for querying the endpoint.

Signed-off-by: Lucas Sta Maria <lucas@priime.dev>